### PR TITLE
Multiqc bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # rnaseq_nextflow
 
 ## ❓ What
-- I am using this repository as a training environment to learn NextFlow and use Docker/containers
+- I am using this repository as a training environment to learn NextFlow
 
 ## 🎯 Aim
-- Learn how to use NextFlow and Docker!
+- Learn how to use NextFlow
 
 ## Details
-As this is an RNAseq pipeline the rnaseq-nf Docker image was used, which can be pulled by:
-```
-$ docker pull nfcore/rnaseq
-```
+- This pipeline is designed to run on the QMUL HPC (Apocrita)
+- Pipeline:
+    1. Subset FASTQ files down to 1M reads
+    2. Run FASTQC on subsetted FASTQ files
+    3. Run TRIMGALORE on full FASTQ files
+    4. Run FASTQC on trimming output
+    5. Run MULTIQC on outputs from FASTQC on subsetted reads and trimmed reads

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -107,6 +107,7 @@ process FASTQC_PT {
  * Perform MultiQC
  */
 process MULTIQC {
+    conda '/data/home/hmy961/.conda/envs/multiqc-env'
     publishDir "${params.analysisdir}", mode:'copy'
 
     input:
@@ -118,9 +119,6 @@ process MULTIQC {
 
     script:
     """
-    module load anaconda3/2023.03
-    conda activate multiqc
-
     # Run multiqc
     multiqc .
     """

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -107,8 +107,6 @@ process FASTQC_PT {
  * Perform MultiQC
  */
 process MULTIQC {
-    conda "/data/WHRI-GenomeCentre/software/multiqc_conda"
-
     input:
     file("*")
     file("*")
@@ -118,6 +116,10 @@ process MULTIQC {
 
     script:
     """
+    # Load gcenv and multiqc module
+    module load python/3.6.3
+    . /data/WHRI-GenomeCentre/gcenv/bin/activate
+
     # Run multiqc
     multiqc .
     """

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -117,7 +117,8 @@ process MULTIQC {
     conda 'multiqc=1.21'
 
     input:
-    path('*')
+    path("1M_fastqc/*")
+    path("post_trim_fastqc/*")
 
     output:
     path("$params.analysisdir/multiqc_report.html")

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -107,9 +107,6 @@ process FASTQC_PT {
  * Perform MultiQC
  */
 process MULTIQC {
-    module load anaconda3
-    conda activate multiqc-env
-
     publishDir "${params.analysisdir}", mode:'copy'
 
     input:
@@ -121,6 +118,9 @@ process MULTIQC {
 
     script:
     """
+    module load anaconda3/2023.03
+    conda activate multiqc-env
+
     # Run multiqc
     multiqc .
     """

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -137,8 +137,8 @@ workflow {
         .fromFilePairs(params.reads, checkIfExists: true)
         .set { read_pairs_ch }
     SUBSAMPLE(read_pairs_ch, params.analysisdir)
-    fastqc_ch = FASTQC(SUBSAMPLE.out.reads, params.analysisdir)
+    FASTQC(SUBSAMPLE.out.reads, params.analysisdir)
     TRIMMING(read_pairs_ch, params.analysisdir)
-    fastqcPT_ch = FASTQC_PT(TRIMMING.out.reads, params.analysisdir)
-    MULTIQC(fastqcPT_ch.mix(fastqc_ch).collect())
+    FASTQC_PT(TRIMMING.out.reads, params.analysisdir)
+    MULTIQC(FASTQC.out.collect(), FASTQC_PT.out.collect())
 }

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -107,7 +107,9 @@ process FASTQC_PT {
  * Perform MultiQC
  */
 process MULTIQC {
-    conda '/data/home/hmy961/.conda/envs/multiqc-env'
+    module load anaconda3
+    conda activate multiqc-env
+
     publishDir "${params.analysisdir}", mode:'copy'
 
     input:

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -107,19 +107,18 @@ process FASTQC_PT {
  * Perform MultiQC
  */
 process MULTIQC {
+    conda 'multiqc=1.21'
+    publishDir "${params.analysisdir}", mode:'copy'
+
     input:
     file("*")
     file("*")
 
     output:
-    path("${params.analysisdir}/multiqc_report.html")
+    path("multiqc_report.html")
 
     script:
     """
-    # Load gcenv and multiqc module
-    module load python/3.6.3
-    . /data/WHRI-GenomeCentre/gcenv/bin/activate
-
     # Run multiqc
     multiqc .
     """
@@ -138,7 +137,5 @@ workflow {
     TRIMMING(read_pairs_ch)
     FASTQC_PT(TRIMMING.out.reads)
     ch_fastqc_trim = FASTQC_PT.out
-    MULTIQC(
-        ch_fastqc.collect(), 
-        ch_fastqc_trim.collect())
+    MULTIQC(ch_fastqc.collect(), ch_fastqc_trim.collect())
 }

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -39,7 +39,7 @@ process FASTQC {
     tuple val(sample_id), path(read1), path(read2)
 
     output:
-    file "*fastqc*" into ch_fastqc
+    file "*fastqc*"
     
     script:
     """
@@ -91,7 +91,7 @@ process FASTQC_PT {
     tuple val(sample_id), path(reads)
 
     output:
-    file "*fastqc*" into ch_fastqc_trim
+    file "*fastqc*"
 
     script:
     """
@@ -132,8 +132,10 @@ workflow {
         .set { read_pairs_ch }
     SUBSAMPLE(read_pairs_ch)
     FASTQC(SUBSAMPLE.out.reads)
+    ch_fastqc = FASTQC.out
     TRIMMING(read_pairs_ch)
     FASTQC_PT(TRIMMING.out.reads)
+    ch_fastqc_trim = FASTQC_PT.out
     MULTIQC(
         ch_fastqc.collect(), 
         ch_fastqc_trim.collect())

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -107,7 +107,7 @@ process FASTQC_PT {
  * Perform MultiQC
  */
 process MULTIQC {
-    conda 'multiqc=1.21'
+    conda "/data/WHRI-GenomeCentre/software/multiqc_conda"
 
     input:
     file("*")

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -107,7 +107,6 @@ process FASTQC_PT {
  * Perform MultiQC
  */
 process MULTIQC {
-    conda 'multiqc=1.21'
     publishDir "${params.analysisdir}", mode:'copy'
 
     input:
@@ -119,6 +118,9 @@ process MULTIQC {
 
     script:
     """
+    module load anaconda3/2023.03
+    conda activate multiqc
+
     # Run multiqc
     multiqc .
     """

--- a/nextflowScriptDev.nf
+++ b/nextflowScriptDev.nf
@@ -14,18 +14,18 @@ log.info """\
  * Sub-sample to 250k reads, 1M lines
  */
 process SUBSAMPLE {
+    publishDir "${params.analysisdir}/1M_Subsample"
+
     input:
     tuple val(sample_id), path(reads)
-    path parentFolder
 
     output:
-    tuple val(sample_id), path("${parentFolder}/1M_Subsample/1M-${sample_id}_R1.fastq"), path("${parentFolder}/1M_Subsample/1M-${sample_id}_R2.fastq"), emit: reads
+    tuple val(sample_id), path("1M-${sample_id}_R1.fastq"), path("1M-${sample_id}_R2.fastq"), emit: reads
 
     script:
     """
-    if [ ! -e ${parentFolder}/1M_Subsample ]; then mkdir -p ${parentFolder}/1M_Subsample; fi
-    gzip -cd ${reads[0]} | head -4000000 > ${parentFolder}/1M_Subsample/1M-${sample_id}_R1.fastq
-    gzip -cd ${reads[1]} | head -4000000 > ${parentFolder}/1M_Subsample/1M-${sample_id}_R2.fastq
+    gzip -cd ${reads[0]} | head -4000000 > 1M-${sample_id}_R1.fastq
+    gzip -cd ${reads[1]} | head -4000000 > 1M-${sample_id}_R2.fastq
     """
 }
 
@@ -33,24 +33,21 @@ process SUBSAMPLE {
  * Perform FastQC
  */
 process FASTQC {
+    publishDir "${params.analysisdir}/1M_fastqc"
+
     input:
     tuple val(sample_id), path(read1), path(read2)
-    path parentFolder
 
     output:
-    tuple val(sample_id), path("*.html"), emit: html
-    tuple val(sample_id), path("*.zip") , emit: fastqc_zip
+    file "*fastqc*" into ch_fastqc
     
     script:
     """
     # Load module
     module load fastqc
-    
-    # Create output folders
-    if [ ! -e ${parentFolder}/1M_fastqc ]; then mkdir -p ${parentFolder}/1M_fastqc; fi
 
     # FastQC files
-    fastqc -o ${parentFolder}/1M_fastqc ${read1} ${read2}
+    fastqc ${read1} ${read2}
     """
 }
 
@@ -58,21 +55,19 @@ process FASTQC {
  * Perform trimming
  */
 process TRIMMING {
+    publishDir "${params.analysisdir}/trimgalore_outs"
+
     input:
     tuple val(sample_id), path(reads)
-    path parentFolder
 
     output:
-    tuple val(sample_id), path("${parentFolder}/trimgalore_outs/*val*.fq.gz"), emit: reads
-	path("${parentFolder}/trimgalore_outs/*report.txt"), optional: true, emit: report
+    tuple val(sample_id), path("*val*.fq.gz"), emit: reads
+	path("*report.txt"), optional: true, emit: report
 
     script:
     """
     # Load module
     module load trimgalore/0.6.5
-
-    # Create output folders
-    if [ ! -e ${parentFolder}/trimgalore_outs ]; then mkdir -p ${parentFolder}/trimgalore_outs; fi
     
 	# Run trimgalore
 	# Options --length, -e, --stringency, --quality are set to default
@@ -82,7 +77,6 @@ process TRIMMING {
 	--paired \
 	--stringency 1 \
 	-e 0.1 \
-	--output_dir ${parentFolder}/trimgalore_outs \
 	${reads}
     """
 }
@@ -91,24 +85,21 @@ process TRIMMING {
  * Perform FastQC, post trimming
  */
 process FASTQC_PT {
+    publishDir "${params.analysisdir}/post_trim_fastqc"
+
     input:
     tuple val(sample_id), path(reads)
-    path parentFolder
 
     output:
-    tuple val(sample_id), path("*.html"), emit: html
-    tuple val(sample_id), path("*.zip") , emit: fastqc_zip
+    file "*fastqc*" into ch_fastqc_trim
 
     script:
     """
     # Load module
     module load fastqc
 
-    # Create output folders
-    if [ ! -e ${parentFolder}/post_trim_fastqc ]; then mkdir -p ${parentFolder}/post_trim_fastqc; fi
-
     # FastQC files
-    fastqc -o ${parentFolder}/post_trim_fastqc ${reads}
+    fastqc ${reads}
     """
 }
 
@@ -119,11 +110,11 @@ process MULTIQC {
     conda 'multiqc=1.21'
 
     input:
-    path("1M_fastqc/*")
-    path("post_trim_fastqc/*")
+    file("*")
+    file("*")
 
     output:
-    path("$params.analysisdir/multiqc_report.html")
+    path("${params.analysisdir}/multiqc_report.html")
 
     script:
     """
@@ -139,13 +130,11 @@ workflow {
     Channel
         .fromFilePairs(params.reads, checkIfExists: true)
         .set { read_pairs_ch }
-    SUBSAMPLE(read_pairs_ch, params.analysisdir)
-    FASTQC(SUBSAMPLE.out.reads, params.analysisdir)
-    ch_fastqc = FASTQC.out.fastqc_zip
-    TRIMMING(read_pairs_ch, params.analysisdir)
-    FASTQC_PT(TRIMMING.out.reads, params.analysisdir)
-    ch_fastqc_trim = FASTQC_PT.out.fastqc_zip
+    SUBSAMPLE(read_pairs_ch)
+    FASTQC(SUBSAMPLE.out.reads)
+    TRIMMING(read_pairs_ch)
+    FASTQC_PT(TRIMMING.out.reads)
     MULTIQC(
-        ch_fastqc.collect{it[1]}.ifEmpty([]), 
-        ch_fastqc_trim.collect{it[1]}.ifEmpty([]))
+        ch_fastqc.collect(), 
+        ch_fastqc_trim.collect())
 }

--- a/nextflowSub.sh
+++ b/nextflowSub.sh
@@ -6,7 +6,6 @@
 #$ -l h_vmem=7.5G
 
 module load nextflow
-module load anaconda3/2023.03
 
 READS='/data/WHRI-GenomeCentre/shares/Projects_RandD/Reference_Datasets/PolyA/GC-JK-9047_copy/Data/201023_NS500784_0721_AHFCJHBGXG/Alignment_1/20201024_095434/Fastq/fastq_lane-merged/*_L001_R{1,2}_001.fastq.gz'
 ANALYSISDIR='/data/WHRI-GenomeCentre/shares/Projects_RandD/Reference_Datasets/PolyA/GC-JK-9047_copy/Analysis/nextflow'


### PR DESCRIPTION
MULTIQC process was not working due to multiple errors and bugs. This PR corrects the scripts in order to fix the bugs and errors. Scripts now run as expected and produce correct outputs.

How the MULTIQC process is run is very important. A Conda environment must be made prior to running the pipeline. This Conda environment must have MULTIQC installed. The Conda environment can then be invoked in the script of the MULTIQC process.